### PR TITLE
ValueError patch

### DIFF
--- a/pang.py
+++ b/pang.py
@@ -12,6 +12,11 @@ try:
 except ImportError:
     gtch = False
 
+try:
+    sys.set_int_max_str_digits(2147483647)
+except AttributeError:
+    pass # Program continues like normal, error can go silently.
+
 class ErrorType(Enum):
     Syntax = auto()
     Command = auto()


### PR DESCRIPTION
Fixed the ValueError where the program exceeds the limit (previously 4300) for integer string conversion.